### PR TITLE
ceph-releases/ALL/centos/daemon-base: change hardcoded nfs-ganesha version

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -3,7 +3,7 @@ yum install -y jq && \
 bash -c ' \
   if [ -n "__GANESHA_PACKAGES__" ]; then \
     if [[ "${CEPH_VERSION}" == master || "${CEPH_VERSION}" == main ]]; then \
-      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.3.2/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
+      curl -s -L "https://shaman.ceph.com/api/repos/nfs-ganesha/V5.5/latest/centos/__ENV_[DISTRO_VERSION]__/flavors/ceph_main/repo?arch=$(arch)" -o /etc/yum.repos.d/ganesha.repo ; \
     elif  [[ "${CEPH_VERSION}" == reef ]]; then \
       echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
       echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \


### PR DESCRIPTION
Change hard-coded nfs-ganesha version V5.3.2 to V5.5.

We are currently pinning the daily nfs-ganesha builds to V5.5 in https://jenkins.ceph.com/job/nfs-ganesha

